### PR TITLE
add github action workflow to run tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tahoe-scorm tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-versions: [2.7, 3.5, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} ${{ matrix.tox-env }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - name: Install dependencies
+        run: |
+          pip install tox
+      - name: Run tox
+        run: |
+          tox


### PR DESCRIPTION
Pretty much a placeholder. Run `tox` via Github Actions for a few different python versions. Right now `tox` just runs `flake8`, and that fails (see #3). This just sets us up for someday running proper tests.