### PR TITLE
Fix long-description causing publish to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Tahoe SCORM XBlock Customizations: Storage Backends.
 
 
 # Change Log
- - `v0.1.3` Fix compatiblity with Tahoe 2.0 configurations
+ - `v0.1.3` Fix compatibility with Tahoe 2.0 configurations
  - `v0.1.2` Fix ImportError on Python 3.5
  - `v0.1.1` First release

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Tahoe SCORM XBlock Customizations: Storage Backends.
 
 
 # Change Log
- - `v0.1.3` Fix compatibility with Tahoe 2.0 configurations
+ - `v0.1.4` Fix compatibility with Tahoe 2.0 configurations
  - `v0.1.2` Fix ImportError on Python 3.5
  - `v0.1.1` First release

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='tahoe-scorm',
-    version='0.1.3',
+    version='0.1.4',
     description='Tahoe SCORM Customizations package.',
     packages=[
         'tahoe_scorm',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 """Set up for the Tahoe SCORM Customizations package."""
 
+from pathlib import Path
 from setuptools import setup
+
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='tahoe-scorm',
@@ -9,4 +14,6 @@ setup(
     packages=[
         'tahoe_scorm',
     ],
+    long_description=long_description,
+    long_description_content_type='text/markdown',
 )


### PR DESCRIPTION
## Change description

Fix `long-description` causing publish to fail. Fix reference: [Including your README in your package’s metadata](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata)

```
Checking dist/tahoe_scorm-0.1.3-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.                                   
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking dist/tahoe-scorm-0.1.3.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
WARNING  `long_description` missing.     
```

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
