### PR TITLE
Make course-org based storage_loc and domain optional, defaulting to On

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Tahoe SCORM XBlock Customizations: Storage Backends.
 
 
 # Change Log
+ - `v0.2.0` Allow override of course_org determined s3 domain (defaults to using course_org)
  - `v0.1.4` Fix compatibility with Tahoe 2.0 configurations
  - `v0.1.2` Fix ImportError on Python 3.5
  - `v0.1.1` First release

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='tahoe-scorm',
-    version='0.1.4',
+    version='0.2.0',
     description='Tahoe SCORM Customizations package.',
     packages=[
         'tahoe_scorm',

--- a/tahoe_scorm/storages.py
+++ b/tahoe_scorm/storages.py
@@ -7,8 +7,8 @@ def tahoe_scorm_storage(xblock):
     """
     Multi-tenant SCORM storage backend for overhangio/openedx-scorm-xblock. The
     following function returns a custom Django storages backend in which the
-    location is determined based on a combination of a settings and the
-    course_org_filter site settings.
+    location is determined based on a combination of a settings and,
+    by default, the course_org_filter site settings.
     The Tahoe default file storage backend is S3Boto3Storage, so is the one this
     function will return.
     """
@@ -16,33 +16,38 @@ def tahoe_scorm_storage(xblock):
     from django.core.files.storage import get_storage_class
     from openedx.core.djangoapps.appsembler.api.sites import get_site_for_course
 
-    # retrieve the site based on the course site id, it will work in the LMS and Studio as well.
-    current_site = get_site_for_course(xblock.course_id)
+    # in Tahoe we use 'storages.backends.s3boto3.S3Boto3Storage'
+    storage_class = get_storage_class(settings.DEFAULT_FILE_STORAGE)
 
     # the root dir inside the S3 bucket, configurable in global settings
     scorm_sub_folder = getattr(settings, "TAHOE_SCORM_XBLOCK_ROOT_DIR", None)
+
     if not scorm_sub_folder:
         raise ScormException(
             'TAHOE_SCORM_XBLOCK_ROOT_DIR is not defined in Django settings. '
             'Please fix it so tahoe_scorm_storage works.'
         )
 
-    # we use course organization id filter as customer SCORM folder
-    site_scorm_folder = str(xblock.course_id.org)
-
-    # in Tahoe we use 'storages.backends.s3boto3.S3Boto3Storage'
-    storage_class = get_storage_class(settings.DEFAULT_FILE_STORAGE)
-    storage_location = os.path.join(scorm_sub_folder, site_scorm_folder)
     # in order to allow CORS restrictions in the browser we need to use a custom
     # domain for the storage. Then in Nginx we have a proxy for the location,
     # but again, in order to allow CORS issues, if we browsing the content in
     # the LMS, the file must come from the LMS, and in Studio from Studio.
     # We cannot simply rely on settings for LMS and Studio URLs, because we need
     # to keep custom domains inside the ecuation.
-    if settings.SERVICE_VARIANT == "lms":
-        s3_custom_domain = current_site.domain
+    s3_custom_domain = settings.SITE_NAME
+
+    if getattr(settings, "TAHOE_SCORM_USE_COURSE_ORG_FOR_DOMAIN", True):
+        # retrieve the site based on the course site id, it will work in the LMS and Studio as well.
+        current_site = get_site_for_course(xblock.course_id)
+
+        # we use course organization id filter as customer SCORM folder
+        site_scorm_folder = str(xblock.course_id.org)
+        storage_location = os.path.join(scorm_sub_folder, site_scorm_folder)
+
+        if settings.SERVICE_VARIANT == "lms":
+            s3_custom_domain = current_site.domain
     else:
-        s3_custom_domain = settings.SITE_NAME
+        storage_location = scorm_sub_folder
 
     return storage_class(
         location=storage_location,


### PR DESCRIPTION

## Change description

Use a new ENV var, `TAHOE_SCORM_USE_COURSE_ORG_FOR_DOMAIN` (defaulting to True) to determine whether to use the course org to get the domain or just use settings.SITE_NAME.  This allows use of tahoe-scorm outside of multitenant Tahoe situation, where we can make use of the proxying feature for CORS compat.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-185

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
